### PR TITLE
Make critical sections compatible with blocks

### DIFF
--- a/src/system/containers/system-pools.c
+++ b/src/system/containers/system-pools.c
@@ -17,29 +17,33 @@ void uel_syspools_init(uel_syspools_t *pools){
 }
 
 uel_event_t *uel_syspools_acquire_event(uel_syspools_t *pools){
+    uel_event_t *event;
     UEL_CRITICAL_ENTER;
-    uel_event_t *event = (uel_event_t *)uel_objpool_acquire(&pools->event_pool);
+    event = (uel_event_t *)uel_objpool_acquire(&pools->event_pool);
     UEL_CRITICAL_EXIT;
     return event;
 }
 
 uel_llist_node_t *uel_syspools_acquire_llist_node(uel_syspools_t *pools){
+    uel_llist_node_t *node;
     UEL_CRITICAL_ENTER;
-    uel_llist_node_t *node = (uel_llist_node_t *)uel_objpool_acquire(&pools->llist_node_pool);
+    node = (uel_llist_node_t *)uel_objpool_acquire(&pools->llist_node_pool);
     UEL_CRITICAL_EXIT;
     return node;
 }
 
 bool uel_syspools_release_event(uel_syspools_t *pools, uel_event_t *event){
+    bool released;
     UEL_CRITICAL_ENTER;
-    bool released = uel_objpool_release(&pools->event_pool, (void *)event);
+    released = uel_objpool_release(&pools->event_pool, (void *)event);
     UEL_CRITICAL_EXIT;
     return released;
 }
 
 bool uel_syspools_release_llist_node(uel_syspools_t *pools, uel_llist_node_t *node){
+    bool released;
     UEL_CRITICAL_ENTER;
-    bool released = uel_objpool_release(&pools->llist_node_pool, (void *)node);
+    released = uel_objpool_release(&pools->llist_node_pool, (void *)node);
     UEL_CRITICAL_EXIT;
     return released;
 }

--- a/src/utils/promise.c
+++ b/src/utils/promise.c
@@ -39,9 +39,9 @@ static inline void push_segment(uel_promise_t *promise, uel_promise_segment_t *s
 static inline void await_promise(uel_promise_t *promise, uel_promise_t *other) {
     promise->state = UEL_PROMISE_PENDING;
 
+    uel_promise_segment_t *segment;
     UEL_CRITICAL_ENTER;
-    uel_promise_segment_t *segment =
-        (uel_promise_segment_t *)uel_objpool_acquire(promise->source->segment_pool);
+    segment = (uel_promise_segment_t *)uel_objpool_acquire(promise->source->segment_pool);
     UEL_CRITICAL_EXIT;
 
     segment->next = promise->first_segment;
@@ -60,8 +60,9 @@ static inline void await_promise(uel_promise_t *promise, uel_promise_t *other) {
 }
 
 static inline void process_segment(uel_promise_t *promise) {
+    uel_promise_segment_t *segment;
     UEL_CRITICAL_ENTER;
-    uel_promise_segment_t *segment = promise->first_segment;
+    segment = promise->first_segment;
     promise->first_segment = segment->next;
     if(!promise->first_segment) promise->last_segment = NULL;
     UEL_CRITICAL_EXIT;
@@ -102,9 +103,9 @@ uel_promise_store_t uel_promise_store_create(
     return store;
 }
 uel_promise_t *uel_promise_create(uel_promise_store_t *store, uel_closure_t closure) {
+    uel_promise_t *promise;
     UEL_CRITICAL_ENTER;
-    uel_promise_t *promise =
-        (uel_promise_t *)uel_objpool_acquire(store->promise_pool);
+    promise = (uel_promise_t *)uel_objpool_acquire(store->promise_pool);
     UEL_CRITICAL_EXIT;
 
     promise->source = store;
@@ -146,9 +147,9 @@ void uel_promise_after(
     uel_closure_t resolve,
     uel_closure_t reject
 ) {
+    uel_promise_segment_t *segment;
     UEL_CRITICAL_ENTER;
-    uel_promise_segment_t *segment =
-        (uel_promise_segment_t *)uel_objpool_acquire(promise->source->segment_pool);
+    segment = (uel_promise_segment_t *)uel_objpool_acquire(promise->source->segment_pool);
     UEL_CRITICAL_EXIT;
 
     segment ->next = NULL;


### PR DESCRIPTION
Critical sections are often managed by creating a block which starts on critical section enter and ends on critical section exit. 

Example:
```c
// critical section begins
{
    volatile uint32_t __irq_bkp;
    __irq_bkp = irq_disable();

    // do atomic operations here

    irq_restore(__irq_bkp);
}
// critical section ends
```

The block holds temporary variables (e.g.: ISR register backup) which are deleted at the end of the block. 
Because of this design, variables which are used after the critical section block should not be created inside the block as they will not exist anymore after once the block exited.

This patch makes this behavior compatible.